### PR TITLE
Fix environment loading for Docker app

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ git clone <repo-url>
 cd multilingual-doc-service
 cp .env .env.local      # adjust variables if desired
 docker compose up --build
+```

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -5,11 +5,15 @@ Using Pydantic for robust parsing & validation.
 """
 
 from functools import lru_cache
-from pydantic import BaseModel, Field
-import os
+from pydantic import Field
+from pydantic_settings import BaseSettings
+from dotenv import load_dotenv
+
+# Load variables from a local .env file when running outside Docker
+load_dotenv()
 
 
-class Settings(BaseModel):
+class Settings(BaseSettings):
     es_host: str = Field(..., env="ES_HOST")
     es_index: str = Field("documents", env="ES_INDEX")
     log_level: str = Field("INFO", env="LOG_LEVEL")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 fastapi==0.111.0
 uvicorn[standard]==0.30.0
 pydantic==2.7.1
+pydantic-settings==2.2.1
 python-dotenv==1.0.1
 elasticsearch==8.13.2
 pytest


### PR DESCRIPTION
## Summary
- use `BaseSettings` and load dotenv in `Settings`
- add missing `pydantic-settings` dependency
- close code block in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r requirements.txt` *(fails: could not find packages because internet is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68791b9872a08330b2c75b334c909a33