### PR TITLE
Fix default configuration for ES host

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -14,7 +14,11 @@ load_dotenv()
 
 
 class Settings(BaseSettings):
-    es_host: str = Field(..., env="ES_HOST")
+    # Provide a sensible default so the service can start even if the
+    # environment variable is not explicitly supplied by docker-compose.
+    # This mirrors the value in ``.env`` and avoids a ValidationError on
+    # startup when the variable is missing.
+    es_host: str = Field("http://elasticsearch:9200", env="ES_HOST")
     es_index: str = Field("documents", env="ES_INDEX")
     log_level: str = Field("INFO", env="LOG_LEVEL")
 


### PR DESCRIPTION
## Summary
- ensure the API starts even if `ES_HOST` isn't provided

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68791d1cf1f88330a64cb5c836020be0